### PR TITLE
Retain task props after decoration

### DIFF
--- a/kolona/task.py
+++ b/kolona/task.py
@@ -1,4 +1,5 @@
 import asyncio
+from functools import update_wrapper
 from time import time
 from typing import Callable, List, Optional
 
@@ -117,7 +118,7 @@ class Task(GlobalTask):
         return self.retry_attempt < self.max_retries
 
 
-def task(*args, queue=None, max_retries=3, retry_intervals=None, **kargs):
+def task(*args, queue=None, max_retries=3, retry_intervals=None, **kwargs):
     """
     @task decorator wraps a function into a GlobalTask which can create a self-contained task object
     """
@@ -126,6 +127,7 @@ def task(*args, queue=None, max_retries=3, retry_intervals=None, **kargs):
         task = GlobalTask(
             func, queue=queue, max_retries=max_retries, retry_intervals=retry_intervals
         )
+        update_wrapper(task, func)
         return task
 
     return wrapper

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -212,3 +212,19 @@ async def test_with_task_args(mocker):
         assert l.kwargs["extra"] == {"arg_0": 1337, "name": "Rough"}
 
     assert queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_decorated_task_retains_original_props():
+    """
+    Decorated taks retains __name__, __doc__ and other magic attributes.
+    """
+    queue = asyncio.Queue()
+
+    @task(queue=queue)
+    async def runner():
+        """docs"""
+        return True
+
+    assert runner.__name__ == "runner"
+    assert runner.__doc__ == "docs"


### PR DESCRIPTION
`@task` used to override `__name__`, `__doc__` and other special properties of a decorated function.

This change makes sure the original properties are retained.